### PR TITLE
Using SHA1 instead of [NSString hash] in [RNCachingURLProtocol cachePathForRequest]

### DIFF
--- a/CachedWebView.xcodeproj/project.pbxproj
+++ b/CachedWebView.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C800AAE8166E77B20027E1E5 /* NSString+Sha1.m in Sources */ = {isa = PBXBuildFile; fileRef = C800AAE7166E77B20027E1E5 /* NSString+Sha1.m */; };
 		FB237ECE14D5B86100F30AD8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB237ECD14D5B86100F30AD8 /* UIKit.framework */; };
 		FB237ED014D5B86100F30AD8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB237ECF14D5B86100F30AD8 /* Foundation.framework */; };
 		FB237ED214D5B86100F30AD8 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB237ED114D5B86100F30AD8 /* CoreGraphics.framework */; };
@@ -22,6 +23,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		C800AAE6166E77B20027E1E5 /* NSString+Sha1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Sha1.h"; sourceTree = "<group>"; };
+		C800AAE7166E77B20027E1E5 /* NSString+Sha1.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Sha1.m"; sourceTree = "<group>"; };
 		FB237EC914D5B86100F30AD8 /* CachedWebView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CachedWebView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB237ECD14D5B86100F30AD8 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		FB237ECF14D5B86100F30AD8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -61,6 +64,8 @@
 		FB237EBE14D5B86100F30AD8 = {
 			isa = PBXGroup;
 			children = (
+				C800AAE6166E77B20027E1E5 /* NSString+Sha1.h */,
+				C800AAE7166E77B20027E1E5 /* NSString+Sha1.m */,
 				FB39D08214D5BB1F002A6D1A /* README.md */,
 				FB237EEA14D5B87400F30AD8 /* RNCachingURLProtocol.h */,
 				FB237EEB14D5B87400F30AD8 /* RNCachingURLProtocol.m */,
@@ -183,6 +188,7 @@
 				FB237EDA14D5B86100F30AD8 /* main.m in Sources */,
 				FB237EDE14D5B86100F30AD8 /* AppDelegate.m in Sources */,
 				FB237EE114D5B86100F30AD8 /* ViewController.m in Sources */,
+				C800AAE8166E77B20027E1E5 /* NSString+Sha1.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NSString+Sha1.h
+++ b/NSString+Sha1.h
@@ -1,0 +1,19 @@
+
+#import <Foundation/Foundation.h>
+#import <CommonCrypto/CommonDigest.h>
+
+/**
+ * This extension contains several a helper
+ * for creating a sha1 hash from instances of NSString
+ */
+@interface NSString (Sha1)
+
+/**
+ * Creates a SHA1 (hash) representation of NSString.
+ *
+ * @return NSString
+ */
+- (NSString *)sha1;
+
+
+@end

--- a/NSString+Sha1.m
+++ b/NSString+Sha1.m
@@ -1,0 +1,24 @@
+
+#import "NSString+Sha1.h"
+
+@implementation NSString (Sha1)
+
+- (NSString *)sha1
+{
+    // see http://www.makebetterthings.com/iphone/how-to-get-md5-and-sha1-in-objective-c-ios-sdk/
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+    
+    CC_SHA1(data.bytes, data.length, digest);
+    
+    NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+    
+    for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
+        [output appendFormat:@"%02x", digest[i]];
+    }
+    
+    return output;
+}
+
+
+@end

--- a/RNCachingURLProtocol.m
+++ b/RNCachingURLProtocol.m
@@ -27,6 +27,7 @@
 
 #import "RNCachingURLProtocol.h"
 #import "Reachability.h"
+#import "NSString+Sha1.h"
 
 #define WORKAROUND_MUTABLE_COPY_LEAK 1
 
@@ -79,7 +80,9 @@ static NSString *RNCachingURLHeader = @"X-RNCache";
 {
   // This stores in the Caches directory, which can be deleted when space is low, but we only use it for offline access
   NSString *cachesPath = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-  return [cachesPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%x", [[[aRequest URL] absoluteString] hash]]];
+  NSString *fileName = [[[aRequest URL] absoluteString] sha1];
+
+  return [cachesPath stringByAppendingPathComponent:fileName];
 }
 
 - (void)startLoading


### PR DESCRIPTION
Fixes the issue described at https://github.com/rnapier/RNCachingURLProtocol/issues/14 using SHA1 instead of [NSString hash]