### PR TITLE
fix POST replaced by GET

### DIFF
--- a/RNCachingURLProtocol.m
+++ b/RNCachingURLProtocol.m
@@ -246,6 +246,10 @@ static NSString *const kRedirectRequestKey = @"redirectRequest";
                                                                           cachePolicy:[self cachePolicy]
                                                                       timeoutInterval:[self timeoutInterval]];
     [mutableURLRequest setAllHTTPHeaderFields:[self allHTTPHeaderFields]];
+    mutableURLRequest.HTTPMethod = [self HTTPMethod];
+    mutableURLRequest.HTTPBody = [self HTTPBody];
+    mutableURLRequest.HTTPShouldHandleCookies = self.HTTPShouldHandleCookies;
+    mutableURLRequest.HTTPShouldUsePipelining = self.HTTPShouldUsePipelining;
     return mutableURLRequest;
 }
 


### PR DESCRIPTION
I found that I couldn't log in to some websites when this protocol is activated. After checking for a while, I realized that every POST request is replaced by a GET request. So here is the fix.
