### PR TITLE
fix request (except GET method) bug

### DIFF
--- a/RNCachingURLProtocol.m
+++ b/RNCachingURLProtocol.m
@@ -246,6 +246,13 @@ static NSString *const kRedirectRequestKey = @"redirectRequest";
                                                                           cachePolicy:[self cachePolicy]
                                                                       timeoutInterval:[self timeoutInterval]];
     [mutableURLRequest setAllHTTPHeaderFields:[self allHTTPHeaderFields]];
+    if ([self HTTPBodyStream]) {
+        [mutableURLRequest setHTTPBodyStream:[self HTTPBodyStream]];
+    } else {
+        [mutableURLRequest setHTTPBody:[self HTTPBody]];
+    }
+    [mutableURLRequest setHTTPMethod:[self HTTPMethod];
+    
     return mutableURLRequest;
 }
 


### PR DESCRIPTION
if the request HTTP method is not GET, mutableCopyWorkaround also copy HTTPBodyStream, HTTPBody and HTTPMethod to the new one.